### PR TITLE
Bugfix: Wait for transactions to be confirmed

### DIFF
--- a/deployment/src/deploymentUtils.js
+++ b/deployment/src/deploymentUtils.js
@@ -98,7 +98,7 @@ function timeout(ms) {
 async function getReceipt(txHash, url) {
   await timeout(GET_RECEIPT_INTERVAL_IN_MILLISECONDS);
   let receipt = await sendNodeRequest(url, "eth_getTransactionReceipt", txHash);
-  if(receipt === null) {
+  if(receipt === null || !receipt.blockNumber) {
     receipt = await getReceipt(txHash, url);
   }
   return receipt;


### PR DESCRIPTION
Loops on getReceipt() until a blockNumber is returned which indicates
that the transaction has been confirmed.